### PR TITLE
Tweak build system for easier integration

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,20 +1,18 @@
 # CMake rules used to build the public sbgECom library release
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
+# Determine whether this is a standalone project or included by other project
+set( SBGECOM_SDK_STANDALONE_PROJECT OFF )
+if( CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR )
+  set( SBGECOM_SDK_STANDALONE_PROJECT ON ) 
+endif()
+
 project(sbgECom)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# Use a sbgCommonLin as a static library
-add_definitions(-DSBG_COMMON_STATIC_USE -D_CRT_SECURE_NO_WARNINGS)
-
-include_directories(
-	${PROJECT_SOURCE_DIR}/../src/
-	${PROJECT_SOURCE_DIR}/../common/
-)
 
 # Define easier to find output paths
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/../bin/)
@@ -31,29 +29,42 @@ else ()
 endif()
 
 add_library(sbgECom STATIC ${SRC} ${COMMON_SRC})
+add_library(sbgECom::libsbgECom ALIAS sbgECom)
+
+# Include information for the target
+target_include_directories( sbgECom
+  PUBLIC
+    ${PROJECT_SOURCE_DIR}/../src/
+		${PROJECT_SOURCE_DIR}/../common/
+)
+
+# Use a sbgCommonLib as a static library
+target_compile_definitions( sbgECom 
+	PRIVATE
+	  -DSBG_COMMON_STATIC_USE 
+		-D_CRT_SECURE_NO_WARNINGS
+)
 
 if (MSVC)
 	target_link_libraries(sbgECom Ws2_32)
 	#target_compile_definitions(sbgECom PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
-# Add all examples
-add_executable(airDataInput "${PROJECT_SOURCE_DIR}/../examples/airDataInput/src/airDataInput.c")
-target_link_libraries(airDataInput sbgECom)
-add_dependencies(airDataInput sbgECom)
+# skip examples when part of an external project
+if( SBGECOM_SDK_STANDALONE_PROJECT )
+	# Add all examples
+	add_executable(airDataInput "${PROJECT_SOURCE_DIR}/../examples/airDataInput/src/airDataInput.c")
+	target_link_libraries(airDataInput PRIVATE sbgECom::libsbgECom )
 
-add_executable(ellipseMinimal "${PROJECT_SOURCE_DIR}/../examples/ellipseMinimal/src/ellipseMinimal.c")
-target_link_libraries(ellipseMinimal sbgECom)
-add_dependencies(ellipseMinimal sbgECom)
+	add_executable(ellipseMinimal "${PROJECT_SOURCE_DIR}/../examples/ellipseMinimal/src/ellipseMinimal.c")
+	target_link_libraries(ellipseMinimal PRIVATE sbgECom::libsbgECom )
 
-add_executable(ellipseOnboardMagCalib "${PROJECT_SOURCE_DIR}/../examples/ellipseOnboardMagCalib/src/ellipseOnboardMagCalib.c")
-target_link_libraries(ellipseOnboardMagCalib sbgECom)
-add_dependencies(ellipseOnboardMagCalib sbgECom)
+	add_executable(ellipseOnboardMagCalib "${PROJECT_SOURCE_DIR}/../examples/ellipseOnboardMagCalib/src/ellipseOnboardMagCalib.c")
+	target_link_libraries(ellipseOnboardMagCalib PRIVATE sbgECom::libsbgECom )
 
-add_executable(hpInsMinimal "${PROJECT_SOURCE_DIR}/../examples/hpInsMinimal/src/hpInsMinimal.c")
-target_link_libraries(hpInsMinimal sbgECom)
-add_dependencies(hpInsMinimal sbgECom)
+	add_executable(hpInsMinimal "${PROJECT_SOURCE_DIR}/../examples/hpInsMinimal/src/hpInsMinimal.c")
+	target_link_libraries(hpInsMinimal PRIVATE sbgECom::libsbgECom )
 
-add_executable(pulseMinimal "${PROJECT_SOURCE_DIR}/../examples/pulseMinimal/src/pulseMinimal.c")
-target_link_libraries(pulseMinimal sbgECom)
-add_dependencies(pulseMinimal sbgECom)
+	add_executable(pulseMinimal "${PROJECT_SOURCE_DIR}/../examples/pulseMinimal/src/pulseMinimal.c")
+	target_link_libraries(pulseMinimal PRIVATE sbgECom::libsbgECom )
+endif()


### PR DESCRIPTION
Use modern CMake; don't impose configurations,
but carry it along with the library target.

Detect when the library is integrated in an external project.
Do not create example targets if that is the case.