### PR TITLE
Ycdtosa patch fix airspeed typo

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,20 +1,18 @@
 # CMake rules used to build the public sbgECom library release
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
+# Determine whether this is a standalone project or included by other project
+set( SBGECOM_SDK_STANDALONE_PROJECT OFF )
+if( CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR )
+  set( SBGECOM_SDK_STANDALONE_PROJECT ON ) 
+endif()
+
 project(sbgECom)
 
 set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-
-# Use a sbgCommonLin as a static library
-add_definitions(-DSBG_COMMON_STATIC_USE -D_CRT_SECURE_NO_WARNINGS)
-
-include_directories(
-	${PROJECT_SOURCE_DIR}/../src/
-	${PROJECT_SOURCE_DIR}/../common/
-)
 
 # Define easier to find output paths
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/../bin/)
@@ -31,29 +29,42 @@ else ()
 endif()
 
 add_library(sbgECom STATIC ${SRC} ${COMMON_SRC})
+add_library(sbgECom::libsbgECom ALIAS sbgECom)
+
+# Include information for the target
+target_include_directories( sbgECom
+  PUBLIC
+    ${PROJECT_SOURCE_DIR}/../src/
+		${PROJECT_SOURCE_DIR}/../common/
+)
+
+# Use a sbgCommonLib as a static library
+target_compile_definitions( sbgECom 
+	PRIVATE
+	  -DSBG_COMMON_STATIC_USE 
+		-D_CRT_SECURE_NO_WARNINGS
+)
 
 if (MSVC)
 	target_link_libraries(sbgECom Ws2_32)
 	#target_compile_definitions(sbgECom PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
-# Add all examples
-add_executable(airDataInput "${PROJECT_SOURCE_DIR}/../examples/airDataInput/src/airDataInput.c")
-target_link_libraries(airDataInput sbgECom)
-add_dependencies(airDataInput sbgECom)
+# skip examples when part of an external project
+if( SBGECOM_SDK_STANDALONE_PROJECT )
+	# Add all examples
+	add_executable(airDataInput "${PROJECT_SOURCE_DIR}/../examples/airDataInput/src/airDataInput.c")
+	target_link_libraries(airDataInput PRIVATE sbgECom::libsbgECom )
 
-add_executable(ellipseMinimal "${PROJECT_SOURCE_DIR}/../examples/ellipseMinimal/src/ellipseMinimal.c")
-target_link_libraries(ellipseMinimal sbgECom)
-add_dependencies(ellipseMinimal sbgECom)
+	add_executable(ellipseMinimal "${PROJECT_SOURCE_DIR}/../examples/ellipseMinimal/src/ellipseMinimal.c")
+	target_link_libraries(ellipseMinimal PRIVATE sbgECom::libsbgECom )
 
-add_executable(ellipseOnboardMagCalib "${PROJECT_SOURCE_DIR}/../examples/ellipseOnboardMagCalib/src/ellipseOnboardMagCalib.c")
-target_link_libraries(ellipseOnboardMagCalib sbgECom)
-add_dependencies(ellipseOnboardMagCalib sbgECom)
+	add_executable(ellipseOnboardMagCalib "${PROJECT_SOURCE_DIR}/../examples/ellipseOnboardMagCalib/src/ellipseOnboardMagCalib.c")
+	target_link_libraries(ellipseOnboardMagCalib PRIVATE sbgECom::libsbgECom )
 
-add_executable(hpInsMinimal "${PROJECT_SOURCE_DIR}/../examples/hpInsMinimal/src/hpInsMinimal.c")
-target_link_libraries(hpInsMinimal sbgECom)
-add_dependencies(hpInsMinimal sbgECom)
+	add_executable(hpInsMinimal "${PROJECT_SOURCE_DIR}/../examples/hpInsMinimal/src/hpInsMinimal.c")
+	target_link_libraries(hpInsMinimal PRIVATE sbgECom::libsbgECom )
 
-add_executable(pulseMinimal "${PROJECT_SOURCE_DIR}/../examples/pulseMinimal/src/pulseMinimal.c")
-target_link_libraries(pulseMinimal sbgECom)
-add_dependencies(pulseMinimal sbgECom)
+	add_executable(pulseMinimal "${PROJECT_SOURCE_DIR}/../examples/pulseMinimal/src/pulseMinimal.c")
+	target_link_libraries(pulseMinimal PRIVATE sbgECom::libsbgECom )
+endif()

--- a/common/sbgDefines.h
+++ b/common/sbgDefines.h
@@ -259,9 +259,12 @@
  * This macro is used to define a new section of packed structures.
  * All structures defined after this macro will be packed.
  */
+
 #ifdef __GNUC__
 	#define SBG_BEGIN_PACKED()
 #elif defined(__TI_COMPILER_VERSION__)
+	#define SBG_BEGIN_PACKED()
+#elif defined(__clang__)
 	#define SBG_BEGIN_PACKED()
 #elif defined(_MSC_VER)
 	#define SBG_BEGIN_PACKED()	__pragma(pack(push, 1))
@@ -276,6 +279,8 @@
 	#define SBG_PACKED			__attribute__((packed))
 #elif defined(__TI_COMPILER_VERSION__)
 	#define SBG_PACKED			__attribute__((packed))
+#elif defined(__clang__)
+	#define SBG_PACKED			__attribute__((packed))
 #elif defined(_MSC_VER)
 	#define SBG_PACKED
 #else
@@ -288,6 +293,8 @@
 #ifdef __GNUC__
 	#define SBG_END_PACKED()
 #elif defined(__TI_COMPILER_VERSION__)
+	#define SBG_END_PACKED()
+#elif defined(__clang__)
 	#define SBG_END_PACKED()
 #elif defined(_MSC_VER)
 	#define SBG_END_PACKED()		__pragma(pack(pop))

--- a/examples/airDataInput/src/airDataInput.c
+++ b/examples/airDataInput/src/airDataInput.c
@@ -96,7 +96,7 @@ static SbgErrorCode airDataInputSendOneLog(SbgEComHandle *pHandle)
 	// We create a random airspeed between 0 to 12 m.s^-1
 	//
 	airDataLog.trueAirspeed = airDataInputRandFloat(0.0f, 12.0f);
-	airDataLog.status |= SBG_ECOM_AIR_DATA_AIRPSEED_VALID;
+	airDataLog.status |= SBG_ECOM_AIR_DATA_AIRSPEED_VALID;
 
 	//
 	// Write the payload

--- a/src/binaryLogs/sbgEComBinaryLogAirData.h
+++ b/src/binaryLogs/sbgEComBinaryLogAirData.h
@@ -54,8 +54,8 @@ extern "C" {
 #define SBG_ECOM_AIR_DATA_PRESSURE_ABS_VALID		(0x0001u << 1)		/*!< Set to 1 if the pressure field is filled and valid. */
 #define SBG_ECOM_AIR_DATA_ALTITUDE_VALID			(0x0001u << 2)		/*!< Set to 1 if the barometric altitude field is filled and valid. */
 #define SBG_ECOM_AIR_DATA_PRESSURE_DIFF_VALID		(0x0001u << 3)		/*!< Set to 1 if the differential pressure field is filled and valid. */
-#define SBG_ECOM_AIR_DATA_AIRPSEED_VALID			(0x0001u << 4)		/*!< Typo. Keep for compatibility. */
 #define SBG_ECOM_AIR_DATA_AIRSPEED_VALID			(0x0001u << 4)		/*!< Set to 1 if the true airspeed field is filled and valid. */
+#define SBG_ECOM_AIR_DATA_AIRPSEED_VALID			(0x0001u << 4)		/*!< Typo. Keep for compatibility. */
 #define SBG_ECOM_AIR_DATA_TEMPERATURE_VALID			(0x0001u << 5)		/*!< Set to 1 if the output air temperature field is filled and valid. */
 
 //----------------------------------------------------------------------//

--- a/src/binaryLogs/sbgEComBinaryLogAirData.h
+++ b/src/binaryLogs/sbgEComBinaryLogAirData.h
@@ -54,7 +54,8 @@ extern "C" {
 #define SBG_ECOM_AIR_DATA_PRESSURE_ABS_VALID		(0x0001u << 1)		/*!< Set to 1 if the pressure field is filled and valid. */
 #define SBG_ECOM_AIR_DATA_ALTITUDE_VALID			(0x0001u << 2)		/*!< Set to 1 if the barometric altitude field is filled and valid. */
 #define SBG_ECOM_AIR_DATA_PRESSURE_DIFF_VALID		(0x0001u << 3)		/*!< Set to 1 if the differential pressure field is filled and valid. */
-#define SBG_ECOM_AIR_DATA_AIRPSEED_VALID			(0x0001u << 4)		/*!< Set to 1 if the true airspeed field is filled and valid. */
+#define SBG_ECOM_AIR_DATA_AIRPSEED_VALID			(0x0001u << 4)		/*!< Typo. Keep for compatibility. */
+#define SBG_ECOM_AIR_DATA_AIRSPEED_VALID			(0x0001u << 4)		/*!< Set to 1 if the true airspeed field is filled and valid. */
 #define SBG_ECOM_AIR_DATA_TEMPERATURE_VALID			(0x0001u << 5)		/*!< Set to 1 if the output air temperature field is filled and valid. */
 
 //----------------------------------------------------------------------//


### PR DESCRIPTION
There is a small typo on one define PSEED <=> SPEED

This fixes the typo, but keeps the older define for compatibility.

Fell free to drop the old define.