### PR TITLE
sbgecom: add callback on interface read

### DIFF
--- a/common/interfaces/sbgInterface.c
+++ b/common/interfaces/sbgInterface.c
@@ -81,3 +81,14 @@ void sbgInterfaceNameSet(SbgInterface *pInterface, const char *pName)
 		strcpy(pInterface->name, pName+(nameLen-(SBG_ARRAY_SIZE(pInterface->name)-1)));
 	}
 }
+
+void sbgInterfaceSetReadRawCallback(SbgInterface *pInterface, SbgInterfaceReadRawFunc pReadCallback, void *pUserArg)
+{
+  assert(pInterface);
+
+  //
+  // Define the callback and the user argument
+  //
+  pInterface->pReadCallback  = pReadCallback;
+  pInterface->pUserArg       = pUserArg;
+}


### PR DESCRIPTION
I understand that it is a public copy of an internal repo, but please consider if these changes can be applied.

Our application require raw sensor data to be available, I have not found a way to get it, thus added a read callback. Would be great if this can be also implemented in the upstream.